### PR TITLE
Add highlight-symbol-nav-mode

### DIFF
--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -40,7 +40,8 @@
 ;; `highlight-symbol-next-in-defun' and `highlight-symbol-prev-in-defun' allow
 ;; for cycling through the locations of any symbol at point.
 ;; When `highlight-symbol-on-navigation-p' is set, highlighting is triggered
-;; regardless of `highlight-symbol-idle-delay'.
+;; regardless of `highlight-symbol-idle-delay'.  Use `highlight-symbol-nav-mode'
+;; to enable key bindings for navigation.
 ;;
 ;; `highlight-symbol-query-replace' can be used to replace the symbol.
 ;;
@@ -272,6 +273,32 @@ element in of `highlight-symbol-faces'."
   (save-restriction
     (narrow-to-defun)
     (highlight-symbol-jump -1)))
+
+(defvar highlight-symbol-nav-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "M-n") #'highlight-symbol-next)
+    (define-key map (kbd "M-p") #'highlight-symbol-prev)
+    map)
+  "Keymap for `highlight-symbol-nav-mode'.")
+
+;;;###autoload
+(define-minor-mode highlight-symbol-nav-mode
+  "Navigate occurrences of the symbol at point.
+
+When called interactively, toggle `highlight-symbol-nav-mode'.
+With prefix ARG, enable `highlight-symbol-nav-mode' if ARG is
+positive, otherwise disable it.
+
+When called from Lisp, enable `highlight-symbol-nav-mode' if ARG
+is omitted, nil or positive.  If ARG is `toggle', toggle
+`highlight-symbol-nav-mode'.  Otherwise behave as if called
+interactively.
+
+In `highlight-symbol-nav-mode' provide the following key bindings
+to navigate between occurrences of the symbol at point in the
+current buffer.
+
+\\{highlight-symbol-nav-mode-map}")
 
 ;;;###autoload
 (defun highlight-symbol-query-replace (replacement)


### PR DESCRIPTION
This minor mode binds highlight-symbol-prev and highlight-symbol-next to M-p
and M-n respectively.

It is not particularly advanced, but quite convenient.
