### PR TITLE
Navigating within symbol keeps temp highlight on

### DIFF
--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -360,7 +360,8 @@ create the new one."
         (highlight-symbol-temp-highlight))
     (if (eql highlight-symbol-idle-delay 0)
         (highlight-symbol-temp-highlight)
-      (highlight-symbol-mode-remove-temp))))
+      (if (not (equal highlight-symbol (highlight-symbol-get-symbol)))
+	  (highlight-symbol-mode-remove-temp)))))
 
 (defun highlight-symbol-jump (dir)
   "Jump to the next or previous occurence of the symbol at point.


### PR DESCRIPTION
While navigating within symbol, temp highlight is turning off and after a while (the same) symbol is highlighten again. I found this issue very annoing...
