### PR TITLE
Ability to define ignore list for symbol

### DIFF
--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -146,9 +146,9 @@ highlighting the symbols will use these colors/faces in order."
   :type 'boolean
   :group 'highlight-symbol)
 
-(defcustom highlight-symbol-highlight-numbers-p t
-  "Whether or not to highlight numbers."
-  :type 'boolean
+(defcustom highlight-symbol-ignore-list '()
+  "List of exceptions (Regex)."
+  :type '(repeat string)
   :group 'highlight-symbol)
 
 (defvar highlight-symbol-color-index 0)
@@ -335,8 +335,9 @@ before if NLINES is negative."
   "Return a regular expression identifying the symbol at point."
   (let ((symbol (thing-at-point 'symbol)))
     (when (and symbol
-               (or (not highlight-symbol-highlight-numbers-p)
-                   (not (string-match "\\`[0-9]+f?F?[ulUL]*\\'" symbol))))
+	       (not (member 0 (mapcar
+			       (lambda (e) (string-match e symbol))
+			       highlight-symbol-ignore-list))))
       (concat (car highlight-symbol-border-pattern)
 	      (regexp-quote symbol)
 	      (cdr highlight-symbol-border-pattern)))))

--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -147,7 +147,7 @@ highlighting the symbols will use these colors/faces in order."
   :group 'highlight-symbol)
 
 (defcustom highlight-symbol-ignore-list '()
-  "List of exceptions (Regex)."
+  "List of regexp rules that specifies what symbols should not be highlighted."
   :type '(repeat string)
   :group 'highlight-symbol)
 

--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -146,6 +146,11 @@ highlighting the symbols will use these colors/faces in order."
   :type 'boolean
   :group 'highlight-symbol)
 
+(defcustom highlight-symbol-highlight-numbers-p t
+  "Whether or not to highlight numbers."
+  :type 'boolean
+  :group 'highlight-symbol)
+
 (defvar highlight-symbol-color-index 0)
 (make-variable-buffer-local 'highlight-symbol-color-index)
 
@@ -326,16 +331,12 @@ before if NLINES is negative."
       (occur (highlight-symbol-get-symbol) nlines)
     (error "No symbol at point")))
 
-(defun string-integer-p (string)
-  "Test if given string is integer"
-  (if (string-match "\\`[-+]?[0-9]+\\'" string)
-      t
-    nil))
-
 (defun highlight-symbol-get-symbol ()
   "Return a regular expression identifying the symbol at point."
   (let ((symbol (thing-at-point 'symbol)))
-    (when (and symbol (not (string-integer-p symbol)))
+    (when (and symbol
+               (or (not highlight-symbol-highlight-numbers-p)
+                   (not (string-match "\\`[0-9]+f?F?[ulUL]*\\'" symbol))))
       (concat (car highlight-symbol-border-pattern)
 	      (regexp-quote symbol)
 	      (cdr highlight-symbol-border-pattern)))))

--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -326,12 +326,19 @@ before if NLINES is negative."
       (occur (highlight-symbol-get-symbol) nlines)
     (error "No symbol at point")))
 
+(defun string-integer-p (string)
+  "Test if given string is integer"
+  (if (string-match "\\`[-+]?[0-9]+\\'" string)
+      t
+    nil))
+
 (defun highlight-symbol-get-symbol ()
   "Return a regular expression identifying the symbol at point."
   (let ((symbol (thing-at-point 'symbol)))
-    (when symbol (concat (car highlight-symbol-border-pattern)
-                         (regexp-quote symbol)
-                         (cdr highlight-symbol-border-pattern)))))
+    (when (and symbol (not (string-integer-p symbol)))
+      (concat (car highlight-symbol-border-pattern)
+	      (regexp-quote symbol)
+	      (cdr highlight-symbol-border-pattern)))))
 
 (defun highlight-symbol-temp-highlight ()
   "Highlight the current symbol until a command is executed."


### PR DESCRIPTION
I think it's nice feature to have ability to specify list of regexes to filter out symbols that should not be highlighted. For example there is no sense in selecting numbers or keywords. Just added defcustom highlight-symbol-ignore-list. 
Example - ignoring numbers:
```elisp
(highlight-symbol-ignore-list '("\\`[0-9]+f?F?[ulUL]*\\'"))
```