### PR TITLE
Allow changing highlight-symbol-mode's mode-line lighter

### DIFF
--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -200,11 +200,14 @@ message after navigation commands."
           (const :tag "Message after navigation commands" navigation))
   :group 'highlight-symbol)
 
+(defvar highlight-symbol-mode-lighter " hl-s"
+  "The mode-line lighter of Highlight-Symbol mode.")
+
 ;;;###autoload
 (define-minor-mode highlight-symbol-mode
   "Minor mode that highlights the symbol under point throughout the buffer.
 Highlighting takes place after `highlight-symbol-idle-delay'."
-  nil " hl-s" nil
+  nil highlight-symbol-mode-lighter nil
   (if highlight-symbol-mode
       ;; on
       (progn


### PR DESCRIPTION
Personally I set this to "" for all minor-modes whose effect is
primarily visual as I don't need an additional visual reminder
that such a mode is enabled.
