### PR TITLE
Add temp highlight persist defcustom

### DIFF
--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -144,7 +144,9 @@ disabled for all buffers."
   "Whether the temporarily highlighted symbol persists (remains
 highlighted) until the idle timer highlights the next symbol.
 Setting this nil causes the highlight to be removed as soon as
-point moves.")
+point moves."
+  :type 'boolean
+  :group 'highlight-symbol)
 
 (defcustom highlight-symbol-highlight-single-occurrence t
   "Determines if `highlight-symbol-mode' highlights single occurrences.
@@ -447,7 +449,7 @@ create the new one."
     (if (eql highlight-symbol-idle-delay 0)
         (highlight-symbol-temp-highlight)
       (unless (or highlight-symbol-persist-until-change
-               (equal highlight-symbol (highlight-symbol-get-symbol)))
+                  (equal highlight-symbol (highlight-symbol-get-symbol)))
         (highlight-symbol-mode-remove-temp)))))
 
 (defun highlight-symbol-jump (dir)

--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -140,6 +140,12 @@ disabled for all buffers."
   :set 'highlight-symbol-set
   :group 'highlight-symbol)
 
+(defcustom highlight-symbol-persist-until-change nil
+  "Whether the temporarily highlighted symbol persists (remains
+highlighted) until the idle timer highlights the next symbol.
+Setting this nil causes the highlight to be removed as soon as
+point moves.")
+
 (defcustom highlight-symbol-highlight-single-occurrence t
   "Determines if `highlight-symbol-mode' highlights single occurrences.
 If nil, `highlight-symbol-mode' will only highlight a symbol if there are
@@ -440,7 +446,8 @@ create the new one."
         (highlight-symbol-temp-highlight))
     (if (eql highlight-symbol-idle-delay 0)
         (highlight-symbol-temp-highlight)
-      (unless (equal highlight-symbol (highlight-symbol-get-symbol))
+      (unless (or highlight-symbol-persist-until-change
+               (equal highlight-symbol (highlight-symbol-get-symbol)))
         (highlight-symbol-mode-remove-temp)))))
 
 (defun highlight-symbol-jump (dir)


### PR DESCRIPTION
Add a `defcustom` to enable persisting of temporary highlight until it is changed.

This causes the highlight to always be on and only after the idle timer has triggered a new highlighting (or clearing of highlight) is the persisted highlight changed.