### PR TITLE
Deprecate project in preference of symbol-overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 highlight-symbol.el
 ===================
 
+**Deprecated:** use [symbol-overlay](https://github.com/wolray/symbol-overlay). See [this paragraph](https://github.com/wolray/symbol-overlay#advantages) for comparison.
+
 automatic and manual symbol highlighting for Emacs
 
 [![Build Status](https://travis-ci.org/nschum/highlight-symbol.el.png?branch=master)](https://travis-ci.org/nschum/highlight-symbol.el)


### PR DESCRIPTION
symbol-overlay-mode is basically a rewrite of highlight-symbol-mode, but it's better integrated with Emacs and lacks some bugs.

Let's not duplicate the effort between 2 projects, and redirect users to the newer one.