### PR TITLE
fix typo

### DIFF
--- a/highlight-symbol.el
+++ b/highlight-symbol.el
@@ -39,7 +39,7 @@
 ;; The functions `highlight-symbol-next', `highlight-symbol-prev',
 ;; `highlight-symbol-next-in-defun' and `highlight-symbol-prev-in-defun' allow
 ;; for cycling through the locations of any symbol at point.  Use
-;; `highlight-symbol-nav-mode' to enable key bindings (M-p and M-p) for
+;; `highlight-symbol-nav-mode' to enable key bindings (M-p and M-n) for
 ;; navigation. When `highlight-symbol-on-navigation-p' is set, highlighting is
 ;; triggered regardless of `highlight-symbol-idle-delay'.
 ;;


### PR DESCRIPTION
M-p and M-p are the same keybinds